### PR TITLE
Replace npmcdn with unpkg

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -8,11 +8,11 @@
 
     <!-- 1. Load libraries -->
      <!-- Polyfill(s) for older browsers -->
-    <script src="https://npmcdn.com/core-js/client/shim.min.js"></script>
+    <script src="https://unpkg.com/core-js/client/shim.min.js"></script>
 
-    <script src="https://npmcdn.com/zone.js@0.6.12?main=browser"></script>
-    <script src="https://npmcdn.com/reflect-metadata@0.1.3"></script>
-    <script src="https://npmcdn.com/systemjs@0.19.27/dist/system.src.js"></script>
+    <script src="https://unpkg.com/zone.js@0.6.12?main=browser"></script>
+    <script src="https://unpkg.com/reflect-metadata@0.1.3"></script>
+    <script src="https://unpkg.com/systemjs@0.19.27/dist/system.src.js"></script>
 
     <!-- 2. Configure SystemJS -->
     <script src="systemjs.config.js"></script>
@@ -28,7 +28,7 @@
 </html>
 
 
-<!-- 
+<!--
 Copyright 2016 Google Inc. All Rights Reserved.
 Use of this source code is governed by an MIT-style license that
 can be found in the LICENSE file at http://angular.io/license

--- a/src/main/resources/static/systemjs.config.js
+++ b/src/main/resources/static/systemjs.config.js
@@ -11,10 +11,10 @@
   var map = {
     'app':                        'app',
 
-    '@angular':                   'https://npmcdn.com/@angular', // sufficient if we didn't pin the version
-    'rxjs':                       'https://npmcdn.com/rxjs@5.0.0-beta.6',
-    'ts':                         'https://npmcdn.com/plugin-typescript@4.0.10/lib/plugin.js',
-    'typescript':                 'https://npmcdn.com/typescript@1.9.0-dev.20160409/lib/typescript.js',
+    '@angular':                   'https://unpkg.com/@angular', // sufficient if we didn't pin the version
+    'rxjs':                       'https://unpkg.com/rxjs@5.0.0-beta.6',
+    'ts':                         'https://unpkg.com/plugin-typescript@4.0.10/lib/plugin.js',
+    'typescript':                 'https://unpkg.com/typescript@1.9.0-dev.20160409/lib/typescript.js',
  };
 
   //packages tells the System loader how to load when no filename and/or no extension
@@ -34,7 +34,7 @@
   // Add map entries for each angular package
   // only because we're pinning the version with `ngVer`.
   ngPackageNames.forEach(function(pkgName) {
-    map['@angular/'+pkgName] = 'https://npmcdn.com/@angular/' + pkgName + ngVer;
+    map['@angular/'+pkgName] = 'https://unpkg.com/@angular/' + pkgName + ngVer;
   });
 
   // Add package entries for angular packages


### PR DESCRIPTION
Hello.

As you might have heard, npmcdn is in the migration process and will be deprecated soon.
A new address is the https://unpkg.com/

Hope this will be useful.
